### PR TITLE
compensate for angles in visualizer positioning

### DIFF
--- a/src/components/MosaComponents/MosaVisualizer.js
+++ b/src/components/MosaComponents/MosaVisualizer.js
@@ -1,12 +1,7 @@
 import React, { useRef, useEffect } from 'react'
 
 import { Card, Typography, CardContent } from '@material-ui/core'
-import {
-  Canvas,
-  useFrame,
-  useThree,
-  perspectiveCamera,
-} from 'react-three-fiber'
+import { Canvas, useFrame, useThree } from 'react-three-fiber'
 
 const Cylinder = props => {
   const mesh = useRef()
@@ -18,9 +13,9 @@ const Cylinder = props => {
       ref={mesh}
       scale={[1, 1, 1]}
       position={[
-        -1.5 + (L2 / 1000) * 3,
+        -1.5 + (L2 / 1000) * 3 + Math.sin((R1 / 1000 - 0.5) * Math.PI),
         -1.5 + (L0 / 1000) * 3,
-        1.5 - (L1 / 1000) * 3,
+        1.5 - (L1 / 1000) * 3 - Math.sin((R2 / 1000 - 0.5) * Math.PI),
       ]}
       rotation={[
         -Math.PI / 4 + ((-R2 / 1000) * Math.PI) / 2,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please describe your changes in detail -->

Changes the calculation for x/z positioning by adding a trigonometric function of R1/R2 to offset position in the visualizer by an amount to better approximate real-life behavior of maxsr designs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Visualization previously rotated about its center axis, which was less accurate about what devices would do when running.

Technically, this doesn't change the fact that rotation is applied to center of the geometry, but it does change how the visualization presents by also offsetting position when "rotating".

## How Has This Been Tested?

Tested locally, and will verify in build preview.

## Screenshots (if appropriate):

Before / After
![centermass](https://user-images.githubusercontent.com/59325699/97662189-528cf580-1a44-11eb-95d8-c8dddc2923e9.gif)![compensatedmass](https://user-images.githubusercontent.com/59325699/97662196-5456b900-1a44-11eb-8721-4aeb939e6f0d.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
