### PR TITLE
add dark mode toggle to layout/header

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,8 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-
-import { Link } from 'gatsby'
-
 import clsx from 'clsx'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import Drawer from '@material-ui/core/Drawer'
@@ -20,6 +17,8 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import AppsIcon from '@material-ui/icons/Apps'
+import Brightness7Icon from '@material-ui/icons/Brightness7'
+import Brightness4Icon from '@material-ui/icons/Brightness4'
 
 const drawerWidth = 240
 
@@ -80,7 +79,7 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const Header = ({ siteTitle }) => {
+const Header = ({ siteTitle, themePreference, toggleTheme }) => {
   const classes = useStyles()
   const theme = useTheme()
 
@@ -117,6 +116,13 @@ const Header = ({ siteTitle }) => {
           <Typography variant="h6" color="inherit">
             {siteTitle}
           </Typography>
+          <IconButton onClick={toggleTheme} style={{ color: 'white' }}>
+            {themePreference === 'light' ? (
+              <Brightness4Icon />
+            ) : (
+              <Brightness7Icon />
+            )}
+          </IconButton>
         </Toolbar>
       </AppBar>
       <Drawer
@@ -139,14 +145,12 @@ const Header = ({ siteTitle }) => {
         </div>
         <Divider />
         <List>
-          <Link to="/">
-            <ListItem button>
-              <ListItemIcon>
-                <AppsIcon />
-              </ListItemIcon>
-              <ListItemText>Controls</ListItemText>
-            </ListItem>
-          </Link>
+          <ListItem button>
+            <ListItemIcon>
+              <AppsIcon />
+            </ListItemIcon>
+            <ListItemText>Controls</ListItemText>
+          </ListItem>
         </List>
       </Drawer>
     </div>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -5,14 +5,47 @@
  * See: https://www.gatsbyjs.org/docs/static-query/
  */
 
-import React from 'react'
+import React, { useMemo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'
 import './layout.css'
+import { createMuiTheme, ThemeProvider, Link } from '@material-ui/core'
 
 const Layout = ({ children }) => {
+  const [themePreference, setThemePreference] = React.useState('light')
+
+  useEffect(() => {
+    const existingPreference = localStorage.getItem('themePreference')
+    if (existingPreference) {
+      setThemePreference(existingPreference)
+    } else {
+      setThemePreference('light')
+      localStorage.setItem('themePreference', 'light')
+    }
+  }, [setThemePreference])
+
+  const theme = useMemo(
+    () =>
+      createMuiTheme({
+        palette: {
+          type: themePreference,
+        },
+      }),
+    [themePreference]
+  )
+
+  const toggleTheme = () => {
+    if (themePreference === 'light') {
+      setThemePreference('dark')
+      localStorage.setItem('themePreference', 'dark')
+    } else {
+      setThemePreference('light')
+      localStorage.setItem('themePreference', 'light')
+    }
+  }
+
   return (
     <StaticQuery
       query={graphql`
@@ -25,25 +58,31 @@ const Layout = ({ children }) => {
         }
       `}
       render={data => (
-        <div style={{ minHeight: '100vh', backgroundColor: '#FFF' }}>
-          <Header siteTitle={data.site.siteMetadata.title} />
-          <div
-            style={{
-              margin: `0 auto`,
-              maxWidth: 1280,
-              padding: `0px 1.0875rem 1.45rem`,
-              paddingTop: 100,
-            }}
-          >
-            <main>{children}</main>
-            <footer style={{ paddingTop: 10 }}>
-              © {new Date().getFullYear()}, Built with{` `}
-              <a href="https://www.gatsbyjs.org">Gatsby</a> and{' '}
-              <a href="http://material-ui.com/">Material UI</a>. Code available
-              on Github @ <a href="https://github.com/tnxa/mosa">tnxa/mosa</a>
-            </footer>
+        <ThemeProvider theme={theme}>
+          <div style={{ minHeight: '100vh' }}>
+            <Header
+              siteTitle={data.site.siteMetadata.title}
+              themePreference={themePreference}
+              toggleTheme={toggleTheme}
+            />
+            <div
+              style={{
+                margin: `0 auto`,
+                maxWidth: 1280,
+                padding: `4.5rem 1.0875rem 1.45rem`,
+              }}
+            >
+              <main>{children}</main>
+              <footer style={{ paddingTop: 10 }}>
+                © {new Date().getFullYear()}, Built with{` `}
+                <Link href="https://www.gatsbyjs.org">Gatsby</Link> and{' '}
+                <Link href="http://material-ui.com/">Material UI</Link>. Code
+                available on Github @{' '}
+                <Link href="https://github.com/tnxa/mosa">tnxa/mosa</Link>
+              </footer>
+            </div>
           </div>
-        </div>
+        </ThemeProvider>
       )}
     />
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please describe your changes in detail -->
Adds a button to switch between light and dark material UI themes. Wraps content in a theme provider to cause UI elements to reflect the theme.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently we only have a light theme; we have had requests for a dark theme which is relatively trivial to enable via material-ui. Exposing this as a toggle enables users to choose how bright/dark their UI is.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, will test in deploy preview as well.

## Screenshots (if appropriate):
![darkmode](https://user-images.githubusercontent.com/59325699/98068395-8a6bb280-1e21-11eb-99df-5451833f3b50.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
