### PR TITLE
add switches to control available stroke types

### DIFF
--- a/src/config/strokes.js
+++ b/src/config/strokes.js
@@ -11,6 +11,7 @@ import { clampedNum } from '../utils/clamp'
 export const strokes = {
   ShortStrokes: {
     name: 'Short Stroke',
+    enabled: true,
     getStroke: (position, step) => {
       const strokeTime = 800 // .8 seconds
       const distanceFactor = 0.5
@@ -53,6 +54,7 @@ export const strokes = {
   },
   LongStrokes: {
     name: 'Long Stroke',
+    enabled: true,
     getStroke: (position, step) => {
       const strokeTime = 800 // .8 seconds
       const distanceFactor = 0.9
@@ -95,6 +97,7 @@ export const strokes = {
   },
   LongJerky: {
     name: 'Long Jerk',
+    enabled: true,
     getStroke: (position, step) => {
       // const strokeTime = 2000 // 2 seconds
       const maxPercentTravel = 0.75
@@ -145,6 +148,7 @@ export const strokes = {
   },
   Orbit: {
     name: 'Orbit',
+    enabled: true,
     getStroke: (position, step) => {
       const strokeTime = 1 + 3 * Math.random() * 1000 // 1-4 seconds
       const steps = strokeTime / step
@@ -164,6 +168,51 @@ export const strokes = {
       for (let i = 1; i <= steps; i++) {
         // choose next points
         const nL0 = pL0 + 5 * Math.cos((i / steps) * Math.PI),
+          nR1 = pR1 + R1dir * 20 * Math.cos((i / steps) * 2 * Math.PI),
+          nR2 = pR2 + R2dir * 15 * Math.sin((i / steps) * 2 * Math.PI) // can we find a way to center this?
+
+        // append next to stroke points
+        stroke.push({
+          L0: nL0,
+          R1: nR1,
+          R2: nR2,
+        })
+        // for next iteration, new points become previous points
+        pL0 = nL0
+        pR1 = nR1
+        pR2 = nR2
+      }
+      return stroke
+    },
+  },
+
+  Hops: {
+    name: 'Hops',
+    enabled: true,
+    getStroke: (position, step) => {
+      const strokeTime = 1 + 3 * Math.random() * 1000 // 1-4 seconds
+      const steps = strokeTime / step
+      const oL0 = position.L0,
+        oR1 = position.R1,
+        oR2 = position.R2
+
+      let stroke = [],
+        pL0 = oL0, // previous L0 starts as original L0
+        pR1 = oR1, // previous L1 starts as original L1
+        pR2 = oR2 // previous L2 starts as original L2
+
+      // randomize the R1/R2 directions once per "hop"
+      const R1dir = Math.random() >= 0.5 ? 1 : -1,
+        R2dir = Math.random() >= 0.5 ? 1 : -1
+
+      for (let i = 1; i <= steps; i++) {
+        // choose next points
+        const x = (i / steps) * Math.PI
+        const nL0 = clampedNum(
+            pL0 + 50 * ((Math.sin(x) * Math.cos(x)) / Math.abs(Math.sin(x))),
+            0,
+            1000
+          ),
           nR1 = pR1 + R1dir * 20 * Math.cos((i / steps) * 2 * Math.PI),
           nR2 = pR2 + R2dir * 15 * Math.sin((i / steps) * 2 * Math.PI) // can we find a way to center this?
 

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -1,10 +1,18 @@
 import { clampedFloat } from './clamp'
 
-// given an array, return a random item from that array
-export const chooseRandom = choices => {
-  const keys = Object.keys(choices)
+// given an object, return a random value from that object -- TODO: refactor this
+export const chooseRandomStroke = choices => {
+  const enabledChoicesArray = Object.entries(choices).filter(
+    stroke => stroke[1].enabled
+  )
+  const enabledChoices = {}
+  for (const index in enabledChoicesArray) {
+    enabledChoices[enabledChoicesArray[index][0]] =
+      enabledChoicesArray[index][1]
+  }
+  const keys = Object.keys(enabledChoices)
   const randex = Math.floor(Math.random() * keys.length)
-  return choices[keys[randex]]
+  return enabledChoices[keys[randex]]
 }
 
 // insert min/max, get random in between - thanks, MDN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please describe your changes in detail -->
- add switch/toggle controls to enable dynamic setting of available stroke types for random control
- add a field to stroke config to set per-stroke default of enabled/disabled
- add a new stroke type: "Hops"
- change chooseRandom name to chooseRandomStroke since it is only used to choose a random stroke
- add filtering of choices in chooseRandomStroke so it only returns a stroke which is enabled

## Motivation and Context

A user has requested ability to change what strokes are available via the web interface. This enables 


## How Has This Been Tested?

Tested manually in development using SR-VIS. Planning to test with hardware on deploy preview as well.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/59325699/100977224-4e9e3880-3506-11eb-8841-db0e0e54d05a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
