### PR TITLE
add V91's suggested rotation indicator + rounding

### DIFF
--- a/src/components/MosaComponents/MosaMotionControl.js
+++ b/src/components/MosaComponents/MosaMotionControl.js
@@ -132,7 +132,7 @@ const HorizontalSlider = props => {
       step={1}
       min={0}
       max={999}
-      value={value}
+      value={Math.round(value)}
       onChange={handleValueChange}
       valueLabelDisplay={connected ? 'on' : 'off'}
       disabled={!connected}
@@ -159,7 +159,7 @@ const VerticalSlider = props => {
           min={0}
           max={999}
           orientation="vertical"
-          value={value}
+          value={Math.round(value)}
           onChange={handleValueChange}
           valueLabelDisplay={connected ? 'on' : 'off'}
           disabled={!connected}

--- a/src/components/MosaComponents/MosaVisualizer.js
+++ b/src/components/MosaComponents/MosaVisualizer.js
@@ -29,6 +29,33 @@ const Cylinder = props => {
   )
 }
 
+// Courtesy of @V91 on Discord, 2021-01-24
+const RotationIndicator = props => {
+  const mesh = useRef()
+  const { L0, L1, L2, R0, R1, R2 } = props.target
+
+  return (
+    <mesh
+      {...props}
+      ref={mesh}
+      scale={[1, 1, 1]}
+      position={[
+        -1.5 + (L2 / 1000) * 3 + Math.sin((R1 / 1000 - 0.5) * Math.PI),
+        -1.5 + (L0 / 1000) * 3,
+        1.5 - (L1 / 1000) * 3 - Math.sin((R2 / 1000 - 0.5) * Math.PI),
+      ]}
+      rotation={[
+        -Math.PI / 4 + ((-R2 / 1000) * Math.PI) / 2,
+        Math.PI * (3 / 4) + ((R1 / 1000) * Math.PI) / 2,
+        Math.PI * 0.5 + (R0 / 1000) * Math.PI * (135 / 90) - 0.8, // Tip cylinder forward + Rotation * 90 degrees * convert 90 to 135 degrees - offset back to center
+      ]}
+    >
+      <cylinderBufferGeometry args={[0.2, 0.2, 2.5, 8]} />
+      <meshStandardMaterial color={'red'} />
+    </mesh>
+  )
+}
+
 const Camera = props => {
   const ref = useRef()
   const { setDefaultCamera } = useThree()
@@ -54,6 +81,7 @@ export const MosaVisualizer = props => {
           <pointLight position={[10, 10, 10]} />
           <Camera />
           <Cylinder target={target} />
+          <RotationIndicator target={target} />
         </Canvas>
       </CardContent>
     </Card>

--- a/src/components/MosaComponents/MosaVisualizer.js
+++ b/src/components/MosaComponents/MosaVisualizer.js
@@ -47,7 +47,7 @@ const RotationIndicator = props => {
       rotation={[
         -Math.PI / 4 + ((-R2 / 1000) * Math.PI) / 2,
         Math.PI * (3 / 4) + ((R1 / 1000) * Math.PI) / 2,
-        Math.PI * 0.5 + (R0 / 1000) * Math.PI * (135 / 90) - 0.8, // Tip cylinder forward + Rotation * 90 degrees * convert 90 to 135 degrees - offset back to center
+        Math.PI * 0.5 + (-R0 / 1000) * Math.PI * (135 / 90) - 0.8, // Tip cylinder forward + Rotation * 90 degrees * convert 90 to 135 degrees - offset back to center
       ]}
     >
       <cylinderBufferGeometry args={[0.2, 0.2, 2.5, 8]} />


### PR DESCRIPTION
## Description

Contributed by V91 from the Tempest discord server.

- add a rotation indicator to the SR-VIS output
- round the displayed output of the controls to make them more
  visually pleasing (instead of incredibly unnecessarily precise)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows users to see expected rotation output and addresses a visual defect where we show unnecessarily precise output on controls when most users only care about 0-999 with no decimal places.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and verified that this makes the expected visual changes.

I will also verify this in the deploy preview.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
