### PR TITLE
create stored settings context for output range

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Once installation completes:
 
 ## Context
 
-This started out as an experiment in [React][reactjs]/[Gatsby][gatsbyjs] using [web serial][webserial] to interface with OSR firmware and hardware, primarily by producing [t-code][t-code-spec] to be used by the OSR3, OSR2, and now SR6 as developed by [Tempest][tempestvr].
+This started out as an experiment in [React][reactjs]/[Gatsby][gatsbyjs] using [web serial][webserial] to interface with OSR firmware and hardware.
+
+This is accomplished by producing [t-code][t-code-spec] to be used by the OSR3, OSR2, and now SR6 as developed by [Tempest][tempestvr], as well as any other devices which accept [t-code][t-code-spec].
 
 Made possible by the [Web Serial API][webserial]. Bootstrapped with [Gatsby][gatsbyjs] & the [material-ui-starter][material-ui-starter].
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,47 +4,11 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-import React, { useState, useEffect } from 'react'
-import { defaultRange } from './src/config/defaults'
+import React from 'react'
+import { SettingsProvider } from './src/context/SettingsContext'
+
 require('typeface-roboto')
 
-export const SettingsContext = React.createContext()
-
-const Provider = ({ children }) => {
-  // store our range settings in localStorage, retrieve them on load.
-  const [mosaSettings, setMosaSettings] = useState(defaultRange)
-
-  // once, on load, try to load settings from localStorage
-  // if we can't find them, create them in localStorage
-  useEffect(() => {
-    // we can store strings, not objects, in localstorage
-    const existingMosaSettings = JSON.parse(
-      localStorage.getItem('mosaSettings')
-    )
-    if (existingMosaSettings) {
-      setMosaSettings(existingMosaSettings)
-    } else {
-      setMosaSettings(defaultRange)
-      // we can store strings, not objects, in localstorage
-      localStorage.setItem('mosaSettings', JSON.stringify(defaultRange))
-    }
-  }, [setMosaSettings])
-
-  const updateSettings = newSettings => {
-    setMosaSettings(newSettings)
-    localStorage.setItem('mosaSettings', JSON.stringify(newSettings))
-  }
-
-  return (
-    <SettingsContext.Provider
-      value={{
-        settings: mosaSettings,
-        updateSettings: updateSettings,
-      }}
-    >
-      {children}
-    </SettingsContext.Provider>
-  )
-}
-
-export const wrapRootElement = ({ element }) => <Provider>{element}</Provider>
+export const wrapRootElement = ({ element }) => (
+  <SettingsProvider>{element}</SettingsProvider>
+)

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,47 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-require('typeface-roboto');
+import React, { useState, useEffect } from 'react'
+import { defaultRange } from './src/config/defaults'
+require('typeface-roboto')
+
+export const SettingsContext = React.createContext()
+
+const Provider = ({ children }) => {
+  // store our range settings in localStorage, retrieve them on load.
+  const [mosaSettings, setMosaSettings] = useState(defaultRange)
+
+  // once, on load, try to load settings from localStorage
+  // if we can't find them, create them in localStorage
+  useEffect(() => {
+    // we can store strings, not objects, in localstorage
+    const existingMosaSettings = JSON.parse(
+      localStorage.getItem('mosaSettings')
+    )
+    if (existingMosaSettings) {
+      setMosaSettings(existingMosaSettings)
+    } else {
+      setMosaSettings(defaultRange)
+      // we can store strings, not objects, in localstorage
+      localStorage.setItem('mosaSettings', JSON.stringify(defaultRange))
+    }
+  }, [setMosaSettings])
+
+  const updateSettings = newSettings => {
+    setMosaSettings(newSettings)
+    localStorage.setItem('mosaSettings', JSON.stringify(newSettings))
+  }
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        settings: mosaSettings,
+        updateSettings: updateSettings,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export const wrapRootElement = ({ element }) => <Provider>{element}</Provider>

--- a/src/components/MosaComponents/MosaOutputRangeControl.js
+++ b/src/components/MosaComponents/MosaOutputRangeControl.js
@@ -9,14 +9,14 @@ import {
 } from '@material-ui/core'
 
 const MosaOutputRangeControl = props => {
-  const { outputRange, setOutputRange } = props
+  const { settings, updateSettings } = props
 
   const handleRangeChange = (axis, value) => {
     const [min, max] = value
     const newValue = {}
     newValue[axis + 'Min'] = min
     newValue[axis + 'Max'] = max
-    setOutputRange({ ...outputRange, ...newValue })
+    updateSettings({ ...settings, ...newValue })
   }
 
   return (
@@ -26,122 +26,162 @@ const MosaOutputRangeControl = props => {
         <FormGroup row>
           <Slider
             marks={[
-              { value: 100, label: 'L0 @ 100' },
-              { value: 900, label: '900' },
+              { value: 0, label: 'L0' },
+              {
+                value: (settings.L0Min + settings.L0Max) / 2,
+                label: settings.L0Min + ' - ' + settings.L0Max,
+              },
+              { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.L0Min, outputRange.L0Max]}
+            value={[settings.L0Min, settings.L0Max]}
             onChange={(e, value) => handleRangeChange('L0', value)}
           />
           <Slider
             marks={[
-              { value: 100, label: 'L1 @ 100' },
-              { value: 900, label: '900' },
+              { value: 0, label: 'L1' },
+              {
+                value: (settings.L1Min + settings.L1Max) / 2,
+                label: settings.L1Min + ' - ' + settings.L1Max,
+              },
+              { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.L1Min, outputRange.L1Max]}
+            value={[settings.L1Min, settings.L1Max]}
             onChange={(e, value) => handleRangeChange('L1', value)}
           />
           <Slider
             marks={[
-              { value: 100, label: 'L2 @ 100' },
-              { value: 900, label: '900' },
+              { value: 0, label: 'L2' },
+              {
+                value: (settings.L2Min + settings.L2Max) / 2,
+                label: settings.L2Min + ' - ' + settings.L2Max,
+              },
+              { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.L2Min, outputRange.L2Max]}
+            value={[settings.L2Min, settings.L2Max]}
             onChange={(e, value) => handleRangeChange('L2', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'L3' },
+              {
+                value: (settings.L3Min + settings.L3Max) / 2,
+                label: settings.L3Min + ' - ' + settings.L3Max,
+              },
               { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.L3Min, outputRange.L3Max]}
+            value={[settings.L3Min, settings.L3Max]}
             onChange={(e, value) => handleRangeChange('L3', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'R0' },
+              {
+                value: (settings.R0Min + settings.R0Max) / 2,
+                label: settings.R0Min + ' - ' + settings.R0Max,
+              },
               { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.R0Min, outputRange.R0Max]}
+            value={[settings.R0Min, settings.R0Max]}
             onChange={(e, value) => handleRangeChange('R0', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'R1' },
+              {
+                value: (settings.R1Min + settings.R1Max) / 2,
+                label: settings.R1Min + ' - ' + settings.R1Max,
+              },
               { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.R1Min, outputRange.R1Max]}
+            value={[settings.R1Min, settings.R1Max]}
             onChange={(e, value) => handleRangeChange('R1', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'R2' },
+              {
+                value: (settings.R2Min + settings.R2Max) / 2,
+                label: settings.R2Min + ' - ' + settings.R2Max,
+              },
               { value: 999, label: '999' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.R2Min, outputRange.R2Max]}
+            value={[settings.R2Min, settings.R2Max]}
             onChange={(e, value) => handleRangeChange('R2', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'V0' },
+              {
+                value: (settings.V0Min + settings.V0Max) / 2,
+                label: settings.V0Min + ' - ' + settings.V0Max,
+              },
               { value: 999, label: 'MAX' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.V0Min, outputRange.V0Max]}
+            value={[settings.V0Min, settings.V0Max]}
             onChange={(e, value) => handleRangeChange('V0', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'V1' },
+              {
+                value: (settings.V1Min + settings.V1Max) / 2,
+                label: settings.V1Min + ' - ' + settings.V1Max,
+              },
               { value: 999, label: 'MAX' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.V1Min, outputRange.V1Max]}
+            value={[settings.V1Min, settings.V1Max]}
             onChange={(e, value) => handleRangeChange('V1', value)}
           />
           <Slider
             marks={[
               { value: 0, label: 'V2' },
+              {
+                value: (settings.V2Min + settings.V2Max) / 2,
+                label: settings.V2Min + ' - ' + settings.V2Max,
+              },
               { value: 999, label: 'MAX' },
             ]}
             step={1}
             min={0}
             max={999}
             valueLabelDisplay="auto"
-            value={[outputRange.V2Min, outputRange.V2Max]}
+            value={[settings.V2Min, settings.V2Max]}
             onChange={(e, value) => handleRangeChange('V2', value)}
           />
         </FormGroup>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -17,9 +17,9 @@ const Layout = ({ children }) => {
   const [themePreference, setThemePreference] = React.useState('light')
 
   useEffect(() => {
-    const existingPreference = localStorage.getItem('themePreference')
-    if (existingPreference) {
-      setThemePreference(existingPreference)
+    const existingThemePreference = localStorage.getItem('themePreference')
+    if (existingThemePreference) {
+      setThemePreference(existingThemePreference)
     } else {
       setThemePreference('light')
       localStorage.setItem('themePreference', 'light')

--- a/src/context/SettingsContext.js
+++ b/src/context/SettingsContext.js
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react'
+import { defaultRange } from '../config/defaults'
+
+export const SettingsContext = React.createContext()
+
+export const SettingsProvider = ({ children }) => {
+  const [mosaSettings, setMosaSettings] = useState(defaultRange)
+
+  // once, on load, try to load settings from localStorage
+  // if we can't find them, create them in localStorage
+  useEffect(() => {
+    // we can store strings, not objects, in localstorage
+    const existingMosaSettings = JSON.parse(
+      localStorage.getItem('mosaSettings')
+    )
+    if (existingMosaSettings) {
+      setMosaSettings(existingMosaSettings)
+    } else {
+      setMosaSettings(defaultRange)
+      // we can store strings, not objects, in localstorage
+      localStorage.setItem('mosaSettings', JSON.stringify(defaultRange))
+    }
+  }, [setMosaSettings])
+
+  const updateSettings = newSettings => {
+    setMosaSettings(newSettings)
+    localStorage.setItem('mosaSettings', JSON.stringify(newSettings))
+  }
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        settings: mosaSettings,
+        updateSettings: updateSettings,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  )
+}

--- a/src/context/SettingsContext.js
+++ b/src/context/SettingsContext.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import { defaultRange } from '../config/defaults'
 
-export const SettingsContext = React.createContext()
+export const SettingsContext = React.createContext({
+  settings: defaultRange,
+})
 
 export const SettingsProvider = ({ children }) => {
   const [mosaSettings, setMosaSettings] = useState(defaultRange)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,10 +6,12 @@ import SEO from '../components/seo'
 import { Card, Typography, CardContent, Grid, Divider } from '@material-ui/core'
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 
-import { defaultTarget, defaultRange } from '../config/defaults'
+import { defaultRange, defaultTarget } from '../config/defaults'
 
 import { useSerial } from '../hooks/useSerialHook'
 import { scaleAxes, constructTCodeCommand } from '../utils/tcode'
+
+import { SettingsContext } from '../../gatsby-browser'
 
 import MosaOutputRangeControl from '../components/MosaComponents/MosaOutputRangeControl'
 import MosaMotionControl from '../components/MosaComponents/MosaMotionControl'
@@ -27,7 +29,6 @@ const IndexPage = () => {
   const [connected, setConnected] = useState(false)
 
   const [target, setTarget] = useState(defaultTarget)
-  const [outputRange, setOutputRange] = useState(defaultRange)
 
   const [inputMethod, setSelectedInputMethod] = useState('web')
   const [outputMethod, setSelectedOutputMethod] = useState()
@@ -37,10 +38,10 @@ const IndexPage = () => {
   }
 
   // todo: make this better
-  const handleOutputMethodChange = (event, newOutputMethod) => {
+  const handleOutputMethodChange = async (event, newOutputMethod) => {
     if (connected) {
-      handleDisconnectFromSerial() // eventually, all methods
-      handleDisconnectFromVisualization()
+      await handleDisconnectFromSerial() // eventually, all methods
+      await handleDisconnectFromVisualization()
     }
 
     switch (newOutputMethod) {
@@ -74,7 +75,7 @@ const IndexPage = () => {
     }
   }
   const handleDisconnectFromSerial = async () => {
-    commandRobot(defaultTarget, 1)
+    commandRobot(defaultTarget, 1, defaultRange)
     await disconnectFromSerial()
     setConnected(false)
   }
@@ -88,13 +89,13 @@ const IndexPage = () => {
     setConnected(false)
   }
 
-  const commandRobot = (destination, interval) => {
+  const commandRobot = (destination, interval, settings) => {
     // persist target to state
     const newTarget = { ...target, ...destination }
     setTarget(newTarget)
 
     // tell the robot what to do
-    const scaledDestination = scaleAxes(newTarget, outputRange)
+    const scaledDestination = scaleAxes(newTarget, settings)
     const command = constructTCodeCommand(scaledDestination, interval)
     switch (outputMethod) {
       case 'serial':
@@ -109,98 +110,119 @@ const IndexPage = () => {
   }
 
   return (
-    <Layout>
-      <SEO title="Controls" />
-      <Grid container spacing={2} justify="center">
-        <Grid item xs={12} md={4} lg={3}>
-          <Card>
-            <CardContent>
-              <Typography>Input: {!inputMethod && 'none selected'} </Typography>
-              <ToggleButtonGroup
-                value={inputMethod}
-                exclusive
-                onChange={handleInputMethodChange}
-              >
-                <ToggleButton value="web">WEB</ToggleButton>
-                <ToggleButton value="remote" disabled>
-                  REMOTE
-                </ToggleButton>
-              </ToggleButtonGroup>
-              <br />
-              <br />
-              <Typography>
-                Output: {!outputMethod && 'none selected'}
-              </Typography>
-              <ToggleButtonGroup
-                value={outputMethod}
-                exclusive
-                onChange={handleOutputMethodChange}
-              >
-                {isSerialAvailable && (
-                  <ToggleButton value="serial">SERIAL</ToggleButton>
-                )}
-                <ToggleButton value="visualizer">SR-VIS</ToggleButton>
-              </ToggleButtonGroup>
-              <br />
-              <br />
-              <Typography variant="caption">(more I/O coming soon)</Typography>
-              {!isSerialAvailable && ( // if serial not available, explain
-                <>
+    <SettingsContext.Consumer>
+      {({ settings, updateSettings }) => (
+        <Layout>
+          <SEO title="Controls" />
+          <Grid container spacing={2} justify="center">
+            <Grid item xs={12} md={4} lg={3}>
+              <Card>
+                <CardContent>
+                  <Typography>
+                    Input: {!inputMethod && 'none selected'}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={inputMethod}
+                    exclusive
+                    onChange={handleInputMethodChange}
+                  >
+                    <ToggleButton value="web">WEB</ToggleButton>
+                    <ToggleButton value="remote" disabled>
+                      REMOTE
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
                   <br />
                   <Typography>
-                    Could not detect serial capabilities. Please use the latest
-                    version of Chrome, open <code>chrome://flags</code>, and set
-                    <code>#enable-experimental-web-platform-features</code>{' '}
-                    (note that these are experimental features, use at your own
-                    risk, etc etc)
+                    Output: {!outputMethod && 'none selected'}
                   </Typography>
-                </>
-              )}
-            </CardContent>
-          </Card>
-          <hr />
-          <MosaVisualizer target={target} />
-          <hr />
-          <MosaOutputRangeControl
-            outputRange={outputRange}
-            setOutputRange={setOutputRange}
-          />
-        </Grid>
-        <Grid item xs={12} md={4} lg={5}>
-          <MosaMotionControl
-            connected={connected}
-            target={target}
-            commandRobot={commandRobot}
-          />
-          <hr />
-          <MosaVibeControl
-            connected={connected}
-            target={target}
-            commandRobot={commandRobot}
-          />
-        </Grid>
-        <Grid item xs={12} md={4} lg={4}>
-          <MosaPlanarControl
-            connected={connected}
-            commandRobot={commandRobot}
-          />
-          <hr />
-          <MosaRandomControl
-            connected={connected}
-            target={target}
-            commandRobot={commandRobot}
-          />
-          <hr />
-          <MosaSineControl
-            connected={connected}
-            target={target}
-            commandRobot={commandRobot}
-          />
-        </Grid>
-      </Grid>
-      &nbsp;
-      <Divider />
-    </Layout>
+                  <ToggleButtonGroup
+                    value={outputMethod}
+                    exclusive
+                    onChange={handleOutputMethodChange}
+                  >
+                    {isSerialAvailable && (
+                      <ToggleButton value="serial">SERIAL</ToggleButton>
+                    )}
+                    <ToggleButton value="visualizer">SR-VIS</ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
+                  <br />
+                  <Typography variant="caption">
+                    (more I/O coming soon)
+                  </Typography>
+                  {!isSerialAvailable && ( // if serial not available, explain
+                    <>
+                      <br />
+                      <Typography>
+                        Could not detect serial capabilities. Please use the
+                        latest version of Chrome, open{' '}
+                        <code>chrome://flags</code>, and set
+                        <code>
+                          #enable-experimental-web-platform-features
+                        </code>{' '}
+                        (note that these are experimental features, use at your
+                        own risk, etc etc)
+                      </Typography>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+              <hr />
+              <MosaVisualizer target={target} />
+              <hr />
+              <MosaOutputRangeControl
+                settings={settings}
+                updateSettings={updateSettings}
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={5}>
+              <MosaMotionControl
+                connected={connected}
+                target={target}
+                commandRobot={(destination, interval) =>
+                  commandRobot(destination, interval, settings)
+                }
+              />
+              <hr />
+              <MosaVibeControl
+                connected={connected}
+                target={target}
+                commandRobot={(destination, interval) =>
+                  commandRobot(destination, interval, settings)
+                }
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={4}>
+              <MosaPlanarControl
+                connected={connected}
+                commandRobot={(destination, interval) =>
+                  commandRobot(destination, interval, settings)
+                }
+              />
+              <hr />
+              <MosaRandomControl
+                connected={connected}
+                target={target}
+                commandRobot={(destination, interval) =>
+                  commandRobot(destination, interval, settings)
+                }
+              />
+              <hr />
+              <MosaSineControl
+                connected={connected}
+                target={target}
+                commandRobot={(destination, interval) =>
+                  commandRobot(destination, interval, settings)
+                }
+              />
+            </Grid>
+          </Grid>
+          &nbsp;
+          <Divider />
+        </Layout>
+      )}
+    </SettingsContext.Consumer>
   )
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ import { defaultRange, defaultTarget } from '../config/defaults'
 import { useSerial } from '../hooks/useSerialHook'
 import { scaleAxes, constructTCodeCommand } from '../utils/tcode'
 
-import { SettingsContext } from '../../gatsby-browser'
+import { SettingsContext } from '../context/SettingsContext'
 
 import MosaOutputRangeControl from '../components/MosaComponents/MosaOutputRangeControl'
 import MosaMotionControl from '../components/MosaComponents/MosaMotionControl'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please describe your changes in detail -->

- store output range settings in LocalStorage (as a stringified JSON object)
- on app load, retrieve stored output range settings from LocalStorage
- cosmetic: display the output range values beneath the sliders (can see value even when not adjusting)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Manually adjusting settings on every app load is tedious. 
This enables set and forget while the browser remembers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally that settings changes persist even on hot reload / hard refresh.

Will also test in deploy preview.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/59325699/108620712-a6588b80-73f3-11eb-964c-35d35d1d551c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
