### PR TITLE
add testbed and automatic page

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import clsx from 'clsx'
+import { Link } from 'gatsby'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import Drawer from '@material-ui/core/Drawer'
 import CssBaseline from '@material-ui/core/CssBaseline'
@@ -145,12 +146,30 @@ const Header = ({ siteTitle, themePreference, toggleTheme }) => {
         </div>
         <Divider />
         <List>
-          <ListItem button>
-            <ListItemIcon>
-              <AppsIcon />
-            </ListItemIcon>
-            <ListItemText>Controls</ListItemText>
-          </ListItem>
+          <Link to="/">
+            <ListItem button>
+              <ListItemIcon>
+                <AppsIcon />
+              </ListItemIcon>
+              <ListItemText>Home</ListItemText>
+            </ListItem>
+          </Link>
+          <Link to="/testbed">
+            <ListItem button>
+              <ListItemIcon>
+                <AppsIcon />
+              </ListItemIcon>
+              <ListItemText>Testbed</ListItemText>
+            </ListItem>
+          </Link>
+          <Link to="/automatic">
+            <ListItem button>
+              <ListItemIcon>
+                <AppsIcon />
+              </ListItemIcon>
+              <ListItemText>Automatic</ListItemText>
+            </ListItem>
+          </Link>
         </List>
       </Drawer>
     </div>

--- a/src/pages/automatic.js
+++ b/src/pages/automatic.js
@@ -1,0 +1,122 @@
+import React from 'react'
+
+import Layout from '../components/layout'
+import SEO from '../components/seo'
+
+import { Card, Typography, CardContent, Grid, Divider } from '@material-ui/core'
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
+
+import { MosaContext } from '../context/MosaContext'
+
+import MosaOutputRangeControl from '../components/MosaComponents/MosaOutputRangeControl'
+import MosaMotionControl from '../components/MosaComponents/MosaMotionControl'
+import MosaPlanarControl from '../components/MosaComponents/MosaPlanarControl'
+import MosaVibeControl from '../components/MosaComponents/MosaVibeControl'
+import MosaSineControl from '../components/MosaComponents/MosaSineControl'
+import MosaVisualizer from '../components/MosaComponents/MosaVisualizer'
+import MosaRandomControl from '../components/MosaComponents/MosaRandomControl'
+
+const AutomaticPage = () => {
+  return (
+    <MosaContext.Consumer>
+      {({
+        isSerialAvailable,
+        connected,
+        commandRobot,
+        target,
+        inputMethod,
+        handleInputMethodChange,
+        outputMethod,
+        handleOutputMethodChange,
+        settings,
+        updateSettings,
+      }) => (
+        <Layout>
+          <SEO title="Automatic" />
+          <Grid container spacing={2} justify="center">
+            <Grid item xs={12} md={4} lg={3}>
+              <Card>
+                <CardContent>
+                  <Typography>
+                    Input: {!inputMethod && 'none selected'}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={inputMethod}
+                    exclusive
+                    onChange={handleInputMethodChange}
+                  >
+                    <ToggleButton value="web">WEB</ToggleButton>
+                    <ToggleButton value="remote" disabled>
+                      REMOTE
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
+                  <br />
+                  <Typography>
+                    Output: {!outputMethod && 'none selected'}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={outputMethod}
+                    exclusive
+                    onChange={handleOutputMethodChange}
+                  >
+                    {isSerialAvailable && (
+                      <ToggleButton value="serial">SERIAL</ToggleButton>
+                    )}
+                    <ToggleButton value="visualizer">SR-VIS</ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
+                  <br />
+                  <Typography variant="caption">
+                    (more I/O coming soon)
+                  </Typography>
+                  {!isSerialAvailable && ( // if serial not available, explain
+                    <>
+                      <br />
+                      <Typography>
+                        Could not detect serial capabilities. Please use the
+                        latest version of Chrome, open{' '}
+                        <code>chrome://flags</code>, and set
+                        <code>
+                          #enable-experimental-web-platform-features
+                        </code>{' '}
+                        (note that these are experimental features, use at your
+                        own risk, etc etc)
+                      </Typography>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+              <hr />
+
+              <MosaOutputRangeControl
+                settings={settings}
+                updateSettings={updateSettings}
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={5}>
+              <MosaVisualizer target={target} />
+              <hr />
+              <MosaRandomControl
+                connected={connected}
+                target={target}
+                commandRobot={commandRobot}
+              />
+              <hr />
+              <MosaSineControl
+                connected={connected}
+                target={target}
+                commandRobot={commandRobot}
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={4}></Grid>
+          </Grid>
+          &nbsp;
+          <Divider />
+        </Layout>
+      )}
+    </MosaContext.Consumer>
+  )
+}
+
+export default AutomaticPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import Layout from '../components/layout'
 import SEO from '../components/seo'
@@ -32,7 +32,7 @@ const IndexPage = () => {
         updateSettings,
       }) => (
         <Layout>
-          <SEO title="Controls" />
+          <SEO title="Home" />
           <Grid container spacing={2} justify="center">
             <Grid item xs={12} md={4} lg={3}>
               <Card>

--- a/src/pages/testbed.js
+++ b/src/pages/testbed.js
@@ -1,0 +1,124 @@
+import React from 'react'
+
+import Layout from '../components/layout'
+import SEO from '../components/seo'
+
+import { Card, Typography, CardContent, Grid, Divider } from '@material-ui/core'
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
+
+import { MosaContext } from '../context/MosaContext'
+
+import MosaOutputRangeControl from '../components/MosaComponents/MosaOutputRangeControl'
+import MosaMotionControl from '../components/MosaComponents/MosaMotionControl'
+import MosaPlanarControl from '../components/MosaComponents/MosaPlanarControl'
+import MosaVibeControl from '../components/MosaComponents/MosaVibeControl'
+import MosaVisualizer from '../components/MosaComponents/MosaVisualizer'
+
+const TestBedPage = () => {
+  return (
+    <MosaContext.Consumer>
+      {({
+        isSerialAvailable,
+        connected,
+        commandRobot,
+        target,
+        inputMethod,
+        handleInputMethodChange,
+        outputMethod,
+        handleOutputMethodChange,
+        settings,
+        updateSettings,
+      }) => (
+        <Layout>
+          <SEO title="Testbed" />
+          <Grid container spacing={2} justify="center">
+            <Grid item xs={12} md={4} lg={3}>
+              <Card>
+                <CardContent>
+                  <Typography>
+                    Input: {!inputMethod && 'none selected'}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={inputMethod}
+                    exclusive
+                    onChange={handleInputMethodChange}
+                  >
+                    <ToggleButton value="web">WEB</ToggleButton>
+                    <ToggleButton value="remote" disabled>
+                      REMOTE
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
+                  <br />
+                  <Typography>
+                    Output: {!outputMethod && 'none selected'}
+                  </Typography>
+                  <ToggleButtonGroup
+                    value={outputMethod}
+                    exclusive
+                    onChange={handleOutputMethodChange}
+                  >
+                    {isSerialAvailable && (
+                      <ToggleButton value="serial">SERIAL</ToggleButton>
+                    )}
+                    <ToggleButton value="visualizer">SR-VIS</ToggleButton>
+                  </ToggleButtonGroup>
+                  <br />
+                  <br />
+                  <Typography variant="caption">
+                    (more I/O coming soon)
+                  </Typography>
+                  {!isSerialAvailable && ( // if serial not available, explain
+                    <>
+                      <br />
+                      <Typography>
+                        Could not detect serial capabilities. Please use the
+                        latest version of Chrome, open{' '}
+                        <code>chrome://flags</code>, and set
+                        <code>
+                          #enable-experimental-web-platform-features
+                        </code>{' '}
+                        (note that these are experimental features, use at your
+                        own risk, etc etc)
+                      </Typography>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+              <hr />
+              <MosaOutputRangeControl
+                settings={settings}
+                updateSettings={updateSettings}
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={5}>
+              <MosaVisualizer target={target} />
+              <hr />
+              <MosaMotionControl
+                connected={connected}
+                target={target}
+                commandRobot={commandRobot}
+              />
+            </Grid>
+            <Grid item xs={12} md={4} lg={4}>
+              <MosaPlanarControl
+                connected={connected}
+                commandRobot={commandRobot}
+              />
+              <hr />
+              <MosaVibeControl
+                connected={connected}
+                target={target}
+                commandRobot={commandRobot}
+              />
+            </Grid>
+          </Grid>
+          &nbsp;
+          <Divider />
+        </Layout>
+      )}
+    </MosaContext.Consumer>
+  )
+}
+
+export default TestBedPage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please describe your changes in detail -->
- adds two new "views" of the existing controls as "pages" using internal Gatsby links from the drawer menu 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
this scaffolding will enable future development of components to be separated out onto sub-pages (e.g. for power users).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, manually. Will test in the deploy preview.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
